### PR TITLE
Update media.rpy

### DIFF
--- a/media.rpy
+++ b/media.rpy
@@ -1,4 +1,3 @@
-
 init -1000 python:
     config_session = False
     def get_image(file):
@@ -377,8 +376,8 @@ init:
 
 
         $ store.names_list.append('th')
-        $ th_prefix = "~ "
-        $ th_suffix = " ~"
+        $ th_prefix = "«"
+        $ th_suffix = "»"
 
 
 


### PR DESCRIPTION
Эта правка должна убрать риточкины тильды - наследие форумных рпгшечек, где мысли оформляются звёздочками, цветом, подчёркиванием, как угодно, только не литературными кавычками.
